### PR TITLE
Feature/update notice

### DIFF
--- a/libs/base/type.less
+++ b/libs/base/type.less
@@ -136,6 +136,10 @@ a {
     text-decoration: none;
     border-bottom: 1px solid currentColor;
 
+    .ie8 & {
+        text-decoration: underline;
+    }
+
     &:hover,
     &:focus {
         color: @link-hover-color;

--- a/libs/jade/notice.jade
+++ b/libs/jade/notice.jade
@@ -29,6 +29,6 @@ block content
 					| 	&lt;/div&gt;
 					| &lt;/div&gt;
 
-	.notice(style="display:block;")
+	.notice
 		.notice__content
 			p We no longer support Internet Explorer 8. To avoid problems viewing this website, please consider upgrading to #[a.a-external-link(href="#") Google Chrome].

--- a/libs/modules/notice.less
+++ b/libs/modules/notice.less
@@ -2,6 +2,8 @@
  * NOTICE
  *
  * Based on cookie monster
+ *
+ * 
  */
 
 .notice {
@@ -13,10 +15,6 @@
     z-index: 10000;
     @media screen and (max-width: @screen-xs-max) {
         font-size: 14px;
-    }
-    display: none;
-    .ie8 & {
-        display: block;
     }
 }
 


### PR DESCRIPTION
Updates to notice.  The site will use IE conditional comments around the notice so no need to use the .ie8 class in the CSS itself.

ie8 doesn't support currentColor so the links are not underlined.  Added an underline instead.
