### PR TITLE
Update autoprefixer to support iOS8 

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -49,7 +49,7 @@ gulp.task( 'clean-less', function() {
 gulp.task( 'less', function() {
 
 	var postCssPlugins = [
-		autoprefixer({ browsers: ['> 1%','ie >= 8'] }),
+		autoprefixer({ browsers: ['> 1%','last 2 version','ie >= 8'], flexbox: 'no-2009' }),
 		rgbaFallback,
 		opacity,
 		pixrem,

--- a/gulpfile.sample.js
+++ b/gulpfile.sample.js
@@ -41,7 +41,7 @@ function cacheBuster( url, hash ) {
 gulp.task( 'less', function() {
 	
 	var postCssPlugins = [
-		autoprefixer({ browsers: ['> 1%','ie >= 8'] }), 
+		autoprefixer({ browsers: ['> 1%','last 2 version','ie >= 8'], flexbox: 'no-2009' }), 
 		rgbaFallback,
 		opacity,
 		pixrem, 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "autoprefixer": "^6.1.1",
+    "autoprefixer": "^6.3.6",
     "cssnano": "^3.3.2",
     "del": "^2.2.0",
     "gulp": "^3.9.0",


### PR DESCRIPTION
Update the range of browsers supported by autoprefixer to 'last 2 version' and exclude the horribly unreliable pre 2009 flexbox syntax.

Once this is applied you will need to run `npm update` to get the lastest version of autoprefixer.
