### PR TITLE
Bug/PUB-339

### DIFF
--- a/libs/styles/base/print/print.less
+++ b/libs/styles/base/print/print.less
@@ -121,6 +121,13 @@ aside,
 	display: none;
 }
 
+.callout {
+	&--warning      { &:before { background: none; color: @red;    } }
+	&--confirmation { &:before { background: none; color: @green;  } }
+	&--alert        { &:before { background: none; color: @yellow; } }
+	&--quote        { &:before { background: none; color: @gray-2; } }
+}
+
 .accordionContent,
 .collapse-content,
 .revealable__content {


### PR DESCRIPTION
Callout headings in print stylesheet need to be amended to remove
the background colour when the "background graphics" option is
switched on in the print page dialog box when printing a pages from 
a browser.