### PR TITLE
Bug [CMS7-265]: Feedback form appears in budget tool

### DIFF
--- a/libs/styles/modules/feedbackform.less
+++ b/libs/styles/modules/feedbackform.less
@@ -16,6 +16,8 @@
     border-top-width: 2px;
     margin-top: 1em;
     padding-top: 1em;
+    position: relative;
+    z-index: 0;
 
     .is-hidden {
         display: none;


### PR DESCRIPTION
Buggy lightbox in budget calculator displays the feedback form input
fields incorrectly. The solution was to pull the feedback forms z-index
back.

[CMS7-265]