### PR TITLE
Bug [CMS7-304]: Welsh-ify warning callout heading

### DIFF
--- a/libs/styles/modules/callout.less
+++ b/libs/styles/modules/callout.less
@@ -66,6 +66,11 @@
     }
 }
 
+// @NOTE: This feels wrong, but it works.
+html:lang(cy) .callout--warning:before {
+	content: "\f071\00a0 Pwysig";
+}
+
 // Yellow
 .callout--alert,
 .dap-panel--important,


### PR DESCRIPTION
Change the language of the word 'Important' for the Welsh warning callout.

[CMS7-304]